### PR TITLE
Upgrade `nokogiri` due to security fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.5.2'
 source 'https://rubygems.org'
 
 gem 'json-ld'
-gem 'nokogiri'
+gem 'nokogiri', '>= 1.10.4'
 gem 'nokogumbo' # for HTML5 support for RDFa
 gem 'pry'
 gem 'rdf-rdfa'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     method_source (0.9.2)
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
-    nokogiri (1.9.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -61,7 +61,7 @@ PLATFORMS
 
 DEPENDENCIES
   json-ld
-  nokogiri
+  nokogiri (>= 1.10.4)
   nokogumbo
   pry
   rdf-rdfa
@@ -71,4 +71,4 @@ RUBY VERSION
    ruby 2.5.2p104
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
To address [CVE-2019-5477](https://nvd.nist.gov/vuln/detail/CVE-2019-5477) reported.